### PR TITLE
remove reference to es2015 list comprehensions

### DIFF
--- a/resources/public/notebooks/diving-into-clojurescript/7.edn
+++ b/resources/public/notebooks/diving-into-clojurescript/7.edn
@@ -58,8 +58,6 @@
  {:type :markdown :value
   "# List comprehensions
 
-  We can do list comprehensions as we do in es2015, by using `for`.
-
   Let's create a list of points of a 4x4 board:"}
  {:type :input :value
   "(for [x (range 4) y (range 4)]


### PR DESCRIPTION
Array methods are favored over list comprehensions which are non-standard. ES2015 must have decided to remove them.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions